### PR TITLE
Some header inclusion clean-ups.

### DIFF
--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -1,7 +1,7 @@
 #include "msgpack.h"
+#include "msgpack_common.h"
 #include "private/unpack_p.h"
 #include "private/pack_p.h"
-#include <QByteArray>
 
 QVariant MsgPack::unpack(const QByteArray &data)
 {

--- a/src/msgpack.h
+++ b/src/msgpack.h
@@ -1,9 +1,11 @@
 #ifndef MSGPACK_H
 #define MSGPACK_H
-#include <QByteArray>
-#include <QVariantList>
+
 #include "msgpack_common.h"
 #include "msgpack_export.h"
+
+#include <QByteArray>
+#include <QMetaType>
 
 namespace MsgPack
 {

--- a/src/private/pack_p.cpp
+++ b/src/private/pack_p.cpp
@@ -1,7 +1,13 @@
 #include "pack_p.h"
 #include "private/sysdep.h"
-#include <limits>
+
+#include <QByteArray>
 #include <QDebug>
+#include <QMapIterator>
+#include <QString>
+#include <QStringList>
+
+#include <limits>
 
 QHash<QMetaType::Type, MsgPackPrivate::packer_t> MsgPackPrivate::user_packers;
 bool MsgPackPrivate::compatibilityMode = false;

--- a/src/private/pack_p.h
+++ b/src/private/pack_p.h
@@ -1,7 +1,13 @@
 #ifndef PACK_P_H
 #define PACK_P_H
-#include <QVariant>
+
 #include "../msgpack_common.h"
+
+#include <QHash>
+#include <QMetaType>
+
+class QByteArray;
+class QString;
 
 namespace MsgPackPrivate {
 /* if wr (write) == false, packer just moves pointer forward

--- a/src/private/unpack_p.cpp
+++ b/src/private/unpack_p.cpp
@@ -1,6 +1,9 @@
 #include "unpack_p.h"
 #include "sysdep.h"
+
+#include <QByteArray>
 #include <QDebug>
+#include <QMap>
 
 MsgPackPrivate::type_parser_f MsgPackPrivate::unpackers[32] = {
     unpack_nil,

--- a/src/private/unpack_p.h
+++ b/src/private/unpack_p.h
@@ -1,7 +1,10 @@
 #ifndef MSGPACK_P_H
 #define MSGPACK_P_H
-#include <QVariant>
+
 #include "../msgpack_common.h"
+
+#include <QHash>
+#include <QVariant>
 
 namespace MsgPackPrivate
 {


### PR DESCRIPTION
 o Include what is directly used, nothing more.
 o Don't rely on transitive inclusion.
 o Order inclusions as: 1) own, 2) Qt, 3) others.
 o Order inclusions alphabetically.
 o Use forward declarations where possible.
 o Blank line between include guard and #include directives.

Tested on Qt 4.8.6 and Qt 5.4.1.

This incidentally fixes "invalid use of incomplete type ‘class
QStringList’" which I got in pack_p.cpp with Qt 4.8.6.