### PR TITLE
Disable clang build on Travis for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: cpp
 
 compiler:
  - gcc
- - clang
 
 env:
  - QT4_BUILD=ON


### PR DESCRIPTION
Travis runs 12.04 (old!), and there are only PPA packages for
Qt 5.0.2, which contains a bug (1) (which has since been fixed in
(2)) that fails the build when using clang.

We have to either

 * wait until Travis CI moves to 14.04 [3], or
 * someone provides more recent Qt packages for 12.04 (unlikely).

Anyway, the two builds on Travis should now pass.

[1] https://bugreports.qt.io/browse/QTBUG-32100
[2] https://codereview.qt-project.org/#/c/60150/