### PR TITLE
Unpack nil fix

### DIFF
--- a/src/private/unpack_p.cpp
+++ b/src/private/unpack_p.cpp
@@ -63,7 +63,7 @@ quint8 *MsgPackPrivate::unpack_type(QVariant &v, quint8 *p)
 quint8 * MsgPackPrivate::unpack_nil(QVariant &v, quint8 *p)
 {
     Q_UNUSED(p)
-    Q_UNUSED(v)
+    v = QVariant();
     return p + 1;
 }
 


### PR DESCRIPTION
When we unpack alot of data - QVariant - contains previous value, instead of null.
For example

array of packed values [true, false, "text", null]

After unpacking becomes QVariantList(QVariant(true), QVariant(false), QVariant("text"), QVariant("text"))