### PR TITLE
changed QMetaType::Type T to int to allow registration of custom QMet…

### DIFF
--- a/src/msgpack.cpp
+++ b/src/msgpack.cpp
@@ -28,7 +28,7 @@ QByteArray MsgPack::pack(const QVariant &variant)
     return arr;
 }
 
-bool MsgPack::registerPacker(QMetaType::Type qType, qint8 msgpackType, MsgPack::pack_user_f packer)
+bool MsgPack::registerPacker(int qType, qint8 msgpackType, MsgPack::pack_user_f packer)
 {
     return MsgPackPrivate::register_packer(qType, msgpackType, packer);
 }

--- a/src/msgpack.h
+++ b/src/msgpack.h
@@ -13,7 +13,7 @@ namespace MsgPack
     MSGPACK_EXPORT bool registerUnpacker(qint8 msgpackType, unpack_user_f unpacker);
 
     MSGPACK_EXPORT QByteArray pack(const QVariant &variant);
-    MSGPACK_EXPORT bool registerPacker(QMetaType::Type qType, qint8 msgpackType, pack_user_f packer);
+    MSGPACK_EXPORT bool registerPacker(int qType, qint8 msgpackType, pack_user_f packer);
     MSGPACK_EXPORT qint8 msgpackType(int qType);
 
     MSGPACK_EXPORT bool registerType(QMetaType::Type qType, quint8 msgpackType);

--- a/src/private/pack_p.cpp
+++ b/src/private/pack_p.cpp
@@ -11,7 +11,7 @@
 #include <QReadLocker>
 #include <QWriteLocker>
 
-QHash<QMetaType::Type, MsgPackPrivate::packer_t> MsgPackPrivate::user_packers;
+QHash<int, MsgPackPrivate::packer_t> MsgPackPrivate::user_packers;
 bool MsgPackPrivate::compatibilityMode = false;
 QReadWriteLock MsgPackPrivate::packers_lock;
 
@@ -319,7 +319,7 @@ quint8 *MsgPackPrivate::pack_map(const QVariantMap &map, quint8 *p, bool wr, QVe
     return p;
 }
 
-bool MsgPackPrivate::register_packer(QMetaType::Type q_type, qint8 msgpack_type, MsgPack::pack_user_f packer)
+bool MsgPackPrivate::register_packer(int q_type, qint8 msgpack_type, MsgPack::pack_user_f packer)
 {
     QWriteLocker locker(&packers_lock);
     if (user_packers.contains(q_type)) {

--- a/src/private/pack_p.h
+++ b/src/private/pack_p.h
@@ -19,9 +19,9 @@ typedef struct {
     MsgPack::pack_user_f packer;
     qint8 type;
 } packer_t;
-bool register_packer(QMetaType::Type q_type, qint8 msgpack_type, MsgPack::pack_user_f packer);
+bool register_packer(int q_type, qint8 msgpack_type, MsgPack::pack_user_f packer);
 qint8 msgpack_type(QMetaType::Type q_type);
-extern QHash<QMetaType::Type, packer_t> user_packers;
+extern QHash<int, packer_t> user_packers;
 extern QReadWriteLock packers_lock;
 extern bool compatibilityMode;
 


### PR DESCRIPTION
By removing the requirement for QMetaType::Type when registering a packer, I can register any custom QMetaType as such:

Q_DECLARE_METATYPE(MyCustomType)
qRegisterMetaType< MyCustomType>();
MsgPack::registerPacker(QMetaType::type("MyCustomType"), 5, packMyCustomType);
MsgPack::registerUnpacker(5, unpackMyCustomType);

(5 is a random number to represent the msgpack ExtType for MyCustomType)

This is useful when sending-receiving msgpack data to other systems using their own implementations of msgpack in other languages such as python or java, makes it easy to marshall custom data objects using a pre specified MsgPackExtType