### PR TITLE
Improve symbols visibility control

### DIFF
--- a/src/msgpack_export.h
+++ b/src/msgpack_export.h
@@ -3,10 +3,14 @@
 
 #include <QtCore/qglobal.h>
 
-#if defined(MSGPACK_MAKE_LIB) // building lib
-#define MSGPACK_EXPORT Q_DECL_EXPORT
-#else // using lib
-#define MSGPACK_EXPORT Q_DECL_IMPORT
+#ifndef MSGPACK_STATIC
+#  if defined(MSGPACK_MAKE_LIB)
+#    define MSGPACK_EXPORT Q_DECL_EXPORT
+#  else
+#    define MSGPACK_EXPORT Q_DECL_IMPORT
+#  endif
+#else
+#  define MSGPACK_EXPORT
 #endif
 
 #endif // MSGPACK_EXPORT_H


### PR DESCRIPTION
visibility 'hidden' should be normally preferred for static builds,
which is also true for source-in builds as well