### PR TITLE
Fix unpack for uint values 127 < x < 65536

### DIFF
--- a/src/private/unpack_p.cpp
+++ b/src/private/unpack_p.cpp
@@ -130,14 +130,14 @@ quint8 * MsgPackPrivate::unpack_negative_fixint(QVariant &v, quint8 *p)
 
 quint8 * MsgPackPrivate::unpack_uint8(QVariant &v, quint8 *p)
 {
-    v = static_cast<quint8>(*(++p));
+    v = static_cast<quint32>(*(++p));
     return p + 1;
 }
 
 quint8 * MsgPackPrivate::unpack_uint16(QVariant &v, quint8 *p)
 {
     p++;
-    v = _msgpack_load16(quint16, p);
+    v = static_cast<quint32>(_msgpack_load16(quint16, p));
     return p + 2;
 }
 

--- a/tests/mixed/mixed_test.cpp
+++ b/tests/mixed/mixed_test.cpp
@@ -10,12 +10,26 @@ class MixedTest : public QObject
     Q_OBJECT
 
 private Q_SLOTS:
+    void test_uint();
     void test_float();
     void test_double();
     void test_map();
     void test_ext();
     void test_mixed();
 };
+
+void MixedTest::test_uint()
+{
+    for (int i = 0; i <= 32; ++i) {
+        const quint32 u = (0x1UL<<i) - 1;
+        QByteArray packed = MsgPack::pack(u);
+        QVariant unpacked = MsgPack::unpack(packed);
+        QVERIFY2(unpacked.type() == QVariant::Type::UInt,
+                 qPrintable(QString("Unpack failed for value %1. Type is %2").arg(u).arg(unpacked.type())));
+        QVERIFY2(unpacked.toUInt() == u,
+                 qPrintable(QString("Unpack failed for value %1. Type is %2").arg(u).arg(unpacked.type())));
+    }
+}
 
 void MixedTest::test_float()
 {


### PR DESCRIPTION
There is a bug when unpacking unsigned integers in the range 127 < x < 65536.
For those values QVariant gets the an underlying type of "Int". Should be "UInt", though.
